### PR TITLE
Updated CUDA events instead of perf_counter(), added new start_swap column in CSV log, and added pynvml requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "cmake>=3.26",
     "ninja",
     "packaging",
+    "pynvml",
     "setuptools>=61",
     "setuptools-scm>=8.0",
     "torch == 2.5.1",

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,6 +2,7 @@
 cmake>=3.26
 ninja
 packaging
+pynvml
 setuptools>=61
 setuptools-scm>=8
 torch==2.5.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -420,6 +420,7 @@ pydantic-core==2.23.4
     # via pydantic
 pygments==2.18.0
     # via rich
+pynvml
 pyparsing==3.2.0
     # via matplotlib
 pytablewriter==1.2.0

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -115,7 +115,7 @@ class BatchExecuteTiming:
         for i, r in enumerate(self.time_ranges):
             ret |= {
                 f'pp_rank_{i}_start': r.start,
-                f'pp_rank_{i}_start_swap' : r.start_swap,
+                f'pp_rank_{i}_start_swap': r.start_swap,
                 f'pp_rank_{i}_start_recv': r.start_recv,
                 f'pp_rank_{i}_start_inf': r.start_inf,
                 f'pp_rank_{i}_end': r.end,

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -97,6 +97,7 @@ class SequenceStage(enum.Enum):
 @dataclass
 class TimeRange:
     start: float
+    start_swap: float
     start_recv: float
     start_inf: float
     end: float
@@ -114,6 +115,7 @@ class BatchExecuteTiming:
         for i, r in enumerate(self.time_ranges):
             ret |= {
                 f'pp_rank_{i}_start': r.start,
+                f'pp_rank_{i}_start_swap' : r.start_swap,
                 f'pp_rank_{i}_start_recv': r.start_recv,
                 f'pp_rank_{i}_start_inf': r.start_inf,
                 f'pp_rank_{i}_end': r.end,

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -385,7 +385,9 @@ class LocalOrDistributedWorkerBase(WorkerBase):
     ) -> Optional[List[SamplerOutput]]:
         """Executes at least one model step on the given sequences, unless no
         sequences are provided."""
+        timing_events = [torch.cuda.Event(enable_timing=True) for _ in range(4)]
         start_time = time.perf_counter()
+        timing_events[0].record()
 
         inputs = self.prepare_input(execute_model_req)
         if inputs is None:
@@ -395,7 +397,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         num_steps = worker_input.num_steps
 
         self.execute_worker(worker_input)
-        start_recv_time = time.perf_counter()
+        timing_events[1].record()
 
         # If there is no input, we don't need to execute the model.
         if worker_input.num_seq_groups == 0:
@@ -413,7 +415,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     "model_execute_time", torch.tensor(0)).item()
 
         # Time finished receiving intermediate tensors and start inference
-        start_inf_time = time.perf_counter()
+        timing_events[2].record()
 
         output = self.model_runner.execute_model(
             model_input=model_input,
@@ -428,10 +430,13 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         collect_model_execute_time = (
             self.observability_config is not None
             and self.observability_config.collect_model_execute_time)
+        timing_events[3].record()
         if collect_model_execute_time:
             torch.cuda.synchronize()
-            end_time = time.perf_counter()
-        model_execute_time = time.perf_counter() - start_time
+        start_recv_time = start_time + (timing_events[0].elapsed_time(timing_events[1]) / 1000)
+        start_inf_time = start_time + (timing_events[0].elapsed_time(timing_events[2]) / 1000)
+        model_execute_time = (timing_events[0].elapsed_time(timing_events[3]) / 1000)
+        end_time = start_time + model_execute_time
         if not get_pp_group().is_last_rank:
             # output is IntermediateTensors
             assert isinstance(output, IntermediateTensors)

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -461,7 +461,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                 # Append timing of stage N-1
                 output.tensors[
                     f"stage_execute_timestamp_rank{pp_rank}"] = torch.tensor([
-                        start_time, start_swap_time, start_recv_time, start_inf_time, end_time
+                        start_time, start_swap_time, start_recv_time,
+                        start_inf_time, end_time
                     ])
             get_pp_group().send_tensor_dict(output.tensors,
                                             all_gather_group=get_tp_group())
@@ -476,7 +477,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                         f"stage_execute_timestamp_rank{rank}"].tolist()
                 else:
                     stage_execute_timestamp = [
-                        start_time, start_swap_time, start_recv_time, start_inf_time, end_time
+                        start_time, start_swap_time, start_recv_time,
+                        start_inf_time, end_time
                     ]
                 time_range = TimeRange(*stage_execute_timestamp)
                 time_ranges.append(time_range)

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -386,7 +386,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         """Executes at least one model step on the given sequences, unless no
         sequences are provided."""
         timing_events = [
-            torch.cuda.Event(enable_timing=True) for _ in range(4)
+            torch.cuda.Event(enable_timing=True) for _ in range(5)
         ]
         start_time = time.perf_counter()
         timing_events[0].record()
@@ -394,12 +394,13 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         inputs = self.prepare_input(execute_model_req)
         if inputs is None:
             return None
-
         model_input, worker_input, kwargs = inputs
         num_steps = worker_input.num_steps
 
-        self.execute_worker(worker_input)
         timing_events[1].record()
+
+        self.execute_worker(worker_input)
+        timing_events[2].record()
 
         # If there is no input, we don't need to execute the model.
         if worker_input.num_seq_groups == 0:
@@ -417,7 +418,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     "model_execute_time", torch.tensor(0)).item()
 
         # Time finished receiving intermediate tensors and start inference
-        timing_events[2].record()
+        timing_events[3].record()
 
         output = self.model_runner.execute_model(
             model_input=model_input,
@@ -432,14 +433,16 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         collect_model_execute_time = (
             self.observability_config is not None
             and self.observability_config.collect_model_execute_time)
-        timing_events[3].record()
+        timing_events[4].record()
         if collect_model_execute_time:
             torch.cuda.synchronize()
-        start_recv_time = start_time + (
+        start_swap_time = start_time + (
             timing_events[0].elapsed_time(timing_events[1]) / 1000)
-        start_inf_time = start_time + (
+        start_recv_time = start_time + (
             timing_events[0].elapsed_time(timing_events[2]) / 1000)
-        model_execute_time = (timing_events[0].elapsed_time(timing_events[3]) /
+        start_inf_time = start_time + (
+            timing_events[0].elapsed_time(timing_events[3]) / 1000)
+        model_execute_time = (timing_events[0].elapsed_time(timing_events[4]) /
                               1000)
         end_time = start_time + model_execute_time
         if not get_pp_group().is_last_rank:
@@ -458,7 +461,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                 # Append timing of stage N-1
                 output.tensors[
                     f"stage_execute_timestamp_rank{pp_rank}"] = torch.tensor([
-                        start_time, start_recv_time, start_inf_time, end_time
+                        start_time, start_swap_time, start_recv_time, start_inf_time, end_time
                     ])
             get_pp_group().send_tensor_dict(output.tensors,
                                             all_gather_group=get_tp_group())
@@ -473,7 +476,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                         f"stage_execute_timestamp_rank{rank}"].tolist()
                 else:
                     stage_execute_timestamp = [
-                        start_time, start_recv_time, start_inf_time, end_time
+                        start_time, start_swap_time, start_recv_time, start_inf_time, end_time
                     ]
                 time_range = TimeRange(*stage_execute_timestamp)
                 time_ranges.append(time_range)


### PR DESCRIPTION
In worker_base.py, I placed cuda events in place of the perf_counter() calls inside execute_model for start, start_swap (new), start_recv, start_inf, and end.

In sequence.py, added start_swap to dictionary

Added pynvml to tests requirement
